### PR TITLE
CI - Drop Python 3.8

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.8'
+  MAIN_PYTHON_VERSION: '3.9'
   DOCUMENTATION_CNAME: 'grantami.docs.pyansys.com'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Per PyAnsys policy this PR drops support for Python 3.8